### PR TITLE
test: improve processing coverage

### DIFF
--- a/tests/processing/export.test.ts
+++ b/tests/processing/export.test.ts
@@ -114,4 +114,28 @@ describe("Export", () => {
 
     expect(app.vault.create).toHaveBeenCalled();
   });
+
+  test("handles colon in book title", async () => {
+    notebook.title = "Sample Book: A Tale";
+    app.vault.getAbstractFileByPath.mockReturnValue(null);
+    await exportToMarkdown(notebook, app, settings);
+
+    const expectedPath = "exports/Sample Book.md";
+    expect(app.vault.create).toHaveBeenCalledWith(expectedPath, expect.any(String));
+  });
+
+  test("formats quote without page number", async () => {
+    notebook.chapterHighlights[0].highlights.push({ text: "Highlight 4", type: "quote" });
+    app.vault.getAbstractFileByPath.mockReturnValue(null);
+    await exportToMarkdown(notebook, app, settings);
+
+    const md = app.vault.create.mock.calls[0][1] as string;
+    expect(md).toContain("> [!quote] Quote\nHighlight 4");
+  });
+
+  test("throws for invalid highlight type", async () => {
+    (notebook.chapterHighlights[0].highlights as any).push({ text: "Bad", type: "bad" });
+    app.vault.getAbstractFileByPath.mockReturnValue(null);
+    await expect(exportToMarkdown(notebook, app, settings)).rejects.toThrow("Invalid highlight type");
+  });
 });

--- a/tests/processing/parser.test.ts
+++ b/tests/processing/parser.test.ts
@@ -98,4 +98,75 @@ describe("Parser", () => {
       </body></html>`;
     expect(() => kindleHTMLParser(badHtml)).toThrow("Note heading");
   });
+
+  test("throws when previous note heading absent", () => {
+    const badHtml = `
+      <html><body>
+        <div class="bookTitle">Title</div>
+        <div class="authors">Author</div>
+        <div class="sectionHeading">Chapter</div>
+        <div><div class="noteText">Text</div></div>
+      </body></html>`;
+    expect(() => kindleHTMLParser(badHtml)).toThrow("Note heading is empty or not found");
+  });
+
+  test("returns undefined page number when not present", () => {
+    const noPageHtml = `
+      <html><body>
+        <div class="bookTitle">Title</div>
+        <div class="authors">Author</div>
+        <div class="sectionHeading">Chapter</div>
+        <div class="noteHeading">Highlight - Location 10</div>
+        <div class="noteText">Quote</div>
+      </body></html>`;
+
+    const parsed = kindleHTMLParser(noPageHtml);
+    expect(parsed.chapterHighlights[0].highlights[0].pageNumber).toBeUndefined();
+  });
+
+  test("throws when book title empty", () => {
+    const badHtml = `
+      <html><body>
+        <div class="bookTitle"></div>
+        <div class="authors">Author</div>
+      </body></html>`;
+    expect(() => kindleHTMLParser(badHtml)).toThrow("is empty");
+  });
+
+  test("throws when chapter name empty", () => {
+    const badHtml = `
+      <html><body>
+        <div class="bookTitle">Title</div>
+        <div class="authors">Author</div>
+        <div class="sectionHeading"></div>
+        <div class="noteHeading">Highlight - Page 1</div>
+        <div class="noteText">Text</div>
+      </body></html>`;
+    expect(() => kindleHTMLParser(badHtml)).toThrow("Chapter name is empty");
+  });
+
+  test("throws when note text empty", () => {
+    const badHtml = `
+      <html><body>
+        <div class="bookTitle">Title</div>
+        <div class="authors">Author</div>
+        <div class="sectionHeading">Chapter</div>
+        <div class="noteHeading">Highlight - Page 1</div>
+        <div class="noteText"></div>
+      </body></html>`;
+    expect(() => kindleHTMLParser(badHtml)).toThrow("Note text is empty");
+  });
+
+  test("keeps author order when name has multiple commas", () => {
+    const html = `
+      <html><body>
+        <div class="bookTitle">Title</div>
+        <div class="authors">Doe, John, Jr.</div>
+        <div class="sectionHeading">Chapter</div>
+        <div class="noteHeading">Highlight - Page 1</div>
+        <div class="noteText">Text</div>
+      </body></html>`;
+    const parsed = kindleHTMLParser(html);
+    expect(parsed.authors).toEqual(["Doe, John, Jr."]);
+  });
 });


### PR DESCRIPTION
## Summary
- expand export tests to handle colon titles, quotes without page numbers, and invalid highlight types
- add parser tests for edge cases like missing headers, empty fields, and complex author names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893874c23e4832485f30c17ac711d0f