### PR TITLE
chore: set pre-commit autoupdate to monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: monthly
+
 repos:
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7


### PR DESCRIPTION
## Summary
- schedule pre-commit.ci autoupdates to run monthly

------
https://chatgpt.com/codex/tasks/task_e_68a9d2f6bb8c8324bc8cf93466073172